### PR TITLE
Refactor library UI into unified screen with persistent audio bar

### DIFF
--- a/app/src/main/java/com/bsikar/helix/data/LibraryManager.kt
+++ b/app/src/main/java/com/bsikar/helix/data/LibraryManager.kt
@@ -38,6 +38,8 @@ import com.bsikar.helix.data.mapper.toImportedFiles
 import com.bsikar.helix.data.repository.EpubMetadataCacheRepository
 import com.bsikar.helix.data.repository.ChapterRepository
 import com.bsikar.helix.data.repository.AudioChapterRepository
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Serializable
 data class WatchedDirectory(
@@ -60,7 +62,8 @@ data class ImportedFile(
     val sourceUri: String? = null // Store the directory URI if from directory import
 )
 
-class LibraryManager(
+@Singleton
+class LibraryManager @Inject constructor(
     private val context: Context,
     private val preferencesManager: UserPreferencesManager,
     private val bookRepository: BookRepository,

--- a/app/src/main/java/com/bsikar/helix/ui/components/AudioNowPlayingBar.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/components/AudioNowPlayingBar.kt
@@ -1,0 +1,194 @@
+package com.bsikar.helix.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.bsikar.helix.player.PlaybackState
+import com.bsikar.helix.theme.AppTheme
+
+@Composable
+fun AudioNowPlayingBar(
+    playbackState: PlaybackState,
+    theme: AppTheme,
+    modifier: Modifier = Modifier,
+    onExpand: () -> Unit = {},
+    onPlayPause: () -> Unit = {},
+    onSkipForward: () -> Unit = {},
+    onSkipBackward: () -> Unit = {}
+) {
+    val book = playbackState.currentBook ?: return
+    val progress = remember(playbackState.currentPositionMs, playbackState.durationMs) {
+        if (playbackState.durationMs <= 0L) 0f
+        else (playbackState.currentPositionMs.toFloat() / playbackState.durationMs.toFloat()).coerceIn(0f, 1f)
+    }
+
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = theme.surfaceColor.copy(alpha = 0.95f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .background(Color.Transparent)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onExpand)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(book.getEffectiveCoverColor()),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (book.shouldShowCoverArt() && !book.coverImagePath.isNullOrEmpty()) {
+                        AsyncImage(
+                            model = book.coverImagePath,
+                            contentDescription = book.title,
+                            modifier = Modifier.fillMaxWidth(),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.PlayArrow,
+                            contentDescription = null,
+                            tint = theme.primaryTextColor.copy(alpha = theme.alphaMedium)
+                        )
+                    }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 8.dp)
+                ) {
+                    Text(
+                        text = book.title,
+                        color = theme.primaryTextColor,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontWeight = FontWeight.SemiBold
+                    )
+
+                    if (book.author.isNotBlank()) {
+                        Text(
+                            text = book.author,
+                            color = theme.secondaryTextColor,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    playbackState.currentChapter?.let { chapter ->
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = chapter.title,
+                            color = theme.accentColor,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = buildString {
+                            val position = book.getFormattedPosition()
+                            if (position.isNotEmpty()) {
+                                append(position)
+                                append(" · ")
+                            }
+                            val duration = book.getFormattedDuration()
+                            if (duration.isNotEmpty()) {
+                                append(duration)
+                            }
+                        },
+                        color = theme.secondaryTextColor.copy(alpha = theme.alphaHigh),
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onSkipBackward) {
+                        Icon(
+                            imageVector = Icons.Filled.SkipPrevious,
+                            contentDescription = "Previous",
+                            tint = theme.primaryTextColor
+                        )
+                    }
+
+                    IconButton(onClick = onPlayPause) {
+                        Icon(
+                            imageVector = if (playbackState.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                            contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
+                            tint = theme.primaryTextColor
+                        )
+                    }
+
+                    IconButton(onClick = onSkipForward) {
+                        Icon(
+                            imageVector = Icons.Filled.SkipNext,
+                            contentDescription = "Next",
+                            tint = theme.primaryTextColor
+                        )
+                    }
+                }
+            }
+
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp),
+                color = theme.accentColor,
+                trackColor = theme.accentColor.copy(alpha = theme.alphaSubtle)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bsikar/helix/ui/screens/MainApp.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/screens/MainApp.kt
@@ -1,24 +1,22 @@
 package com.bsikar.helix.ui.screens
 
-import androidx.compose.runtime.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.*
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.bsikar.helix.R
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bsikar.helix.data.model.Book
 import com.bsikar.helix.data.model.UiState
-import com.bsikar.helix.data.model.ReadingStatus
 import com.bsikar.helix.data.UserPreferencesManager
 import com.bsikar.helix.theme.AppTheme
 import com.bsikar.helix.theme.ThemeMode
+import com.bsikar.helix.viewmodels.AudioBookReaderViewModel
 import com.bsikar.helix.viewmodels.LibraryViewModel
 import com.bsikar.helix.viewmodels.ReaderViewModel
 import com.bsikar.helix.managers.ImportManager
+import com.bsikar.helix.ui.components.AudioNowPlayingBar
 
 @Composable
 fun MainApp(
@@ -29,33 +27,28 @@ fun MainApp(
     libraryViewModel: LibraryViewModel,
     importManager: ImportManager? = null
 ) {
-    var selectedTab by remember { mutableStateOf(0) }
-    
-    // Redirect any tab 3 selections to tab 0 (Library) since we removed the Listening tab
-    LaunchedEffect(selectedTab) {
-        if (selectedTab >= 3) {
-            selectedTab = 0
-        }
-    }
+    val audioBookReaderViewModel: AudioBookReaderViewModel = hiltViewModel()
+    val playbackState by audioBookReaderViewModel.playbackState.collectAsStateWithLifecycle()
+
     var showSettings by remember { mutableStateOf(false) }
     var settingsScrollTarget by remember { mutableStateOf<String?>(null) }
     var currentBook by remember { mutableStateOf<Book?>(null) }
-    var seeAllData by remember { mutableStateOf<Pair<String, List<com.bsikar.helix.data.model.Book>>?>(null) }
 
-    // Collect states from ViewModel - use filtered results for search functionality
     val allBooks by libraryViewModel.allBooks.collectAsState()
-    val readingBooks by libraryViewModel.filteredReadingBooks.collectAsState()
-    val onDeckBooks by libraryViewModel.filteredOnDeckBooks.collectAsState()
-    val completedBooks by libraryViewModel.filteredCompletedBooks.collectAsState()
-    val recentBooks by libraryViewModel.recentBooks.collectAsState()
+    val filteredBooks by libraryViewModel.filteredLibraryBooks.collectAsState()
+    val searchQuery by libraryViewModel.searchQuery.collectAsState()
+    val contentFilter by libraryViewModel.contentFilter.collectAsState()
+    val activeTagFilters by libraryViewModel.activeTagFilters.collectAsState()
     val libraryState by libraryViewModel.libraryState.collectAsState()
     val errorMessage by libraryViewModel.errorMessage.collectAsState()
-    val searchQuery by libraryViewModel.searchQuery.collectAsState()
-    
-    // Collect sorting states
-    val readingSortAscending by libraryViewModel.readingSortAscending.collectAsState()
-    val onDeckSortAscending by libraryViewModel.onDeckSortAscending.collectAsState()
-    val completedSortAscending by libraryViewModel.completedSortAscending.collectAsState()
+    val isRefreshing by libraryViewModel.isRefreshing.collectAsState()
+    val scanMessage by libraryViewModel.scanMessage.collectAsState()
+
+    val importProgressState = importManager?.importProgress?.collectAsState(initial = emptyList())
+    val importProgress = importProgressState?.value ?: emptyList()
+
+    val showNowPlayingBar = playbackState.currentBook != null &&
+        (playbackState.isPlaying || playbackState.currentPositionMs > 0L)
 
     // Handle global library state (for operations like imports/scans)
     when (libraryState) {
@@ -81,192 +74,108 @@ fun MainApp(
         }
     }
 
-    when {
-        showSettings -> {
-            SettingsScreen(
-                currentTheme = currentTheme,
-                onThemeChange = onThemeChange,
-                theme = theme,
-                onBackClick = { 
-                    showSettings = false
-                    settingsScrollTarget = null
-                },
-                libraryManager = libraryViewModel.libraryManager,
-                scrollToSection = settingsScrollTarget,
-                importManager = importManager
-            )
-        }
-        seeAllData != null -> {
-            SeeAllScreen(
-                title = seeAllData!!.first,
-                books = seeAllData!!.second,
-                theme = theme,
-                onBackClick = { seeAllData = null },
-                onBookClick = { book -> 
-                    currentBook = book
-                    seeAllData = null // Clear see all data to navigate to reader
-                }
-            )
-        }
-        currentBook != null -> {
-            if (currentBook!!.isAudiobook()) {
-                // Automatically mark audiobook as listening when opening
-                LaunchedEffect(currentBook!!.id) {
-                    libraryViewModel.startReading(currentBook!!.id)
-                }
-                AudioBookReaderScreen(
-                    book = currentBook!!,
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            showSettings -> {
+                SettingsScreen(
+                    currentTheme = currentTheme,
+                    onThemeChange = onThemeChange,
                     theme = theme,
-                    onBackClick = { 
-                        currentBook = null 
+                    onBackClick = {
+                        showSettings = false
+                        settingsScrollTarget = null
+                    },
+                    libraryManager = libraryViewModel.libraryManager,
+                    scrollToSection = settingsScrollTarget,
+                    importManager = importManager
+                )
+            }
+            currentBook != null -> {
+                if (currentBook!!.isAudiobook()) {
+                    LaunchedEffect(currentBook!!.id) {
+                        libraryViewModel.startReading(currentBook!!.id)
                     }
-                )
-            } else {
-                val readerViewModel: ReaderViewModel = hiltViewModel()
-                ReaderScreen(
-                    book = currentBook!!,
+                    AudioBookReaderScreen(
+                        book = currentBook!!,
+                        theme = theme,
+                        onBackClick = {
+                            currentBook = null
+                        }
+                    )
+                } else {
+                    val readerViewModel: ReaderViewModel = hiltViewModel()
+                    ReaderScreen(
+                        book = currentBook!!,
+                        theme = theme,
+                        onBackClick = {
+                            currentBook = null
+                        },
+                        onUpdateReadingPosition = { bookId, currentPage, currentChapter, scrollPosition ->
+                            libraryViewModel.updateReadingPosition(bookId, currentPage, currentChapter, scrollPosition)
+                            currentBook = allBooks.find { it.id == bookId } ?: currentBook
+                        },
+                        onUpdateBookSettings = { updatedBook ->
+                            libraryViewModel.updateBookSettings(updatedBook)
+                            currentBook = updatedBook
+                        },
+                        preferencesManager = preferencesManager,
+                        libraryManager = libraryViewModel.libraryManager,
+                        readerViewModel = readerViewModel
+                    )
+                }
+            }
+            else -> {
+                UnifiedLibraryScreen(
                     theme = theme,
-                    onBackClick = { 
-                        currentBook = null 
+                    searchQuery = searchQuery,
+                    onSearchQueryChange = { query -> libraryViewModel.updateSearchQuery(query) },
+                    contentFilter = contentFilter,
+                    onContentFilterChange = { filter -> libraryViewModel.updateContentFilter(filter) },
+                    activeTagFilters = activeTagFilters,
+                    onToggleTagFilter = { tagId -> libraryViewModel.toggleTagFilter(tagId) },
+                    onClearTagFilters = { libraryViewModel.clearTagFilters() },
+                    books = filteredBooks,
+                    allBooks = allBooks,
+                    nowPlayingBookId = playbackState.currentBook?.id,
+                    onBookClick = { book -> currentBook = book },
+                    onStartReading = { bookId -> libraryViewModel.startReading(bookId) },
+                    onMarkCompleted = { bookId -> libraryViewModel.markAsCompleted(bookId) },
+                    onMoveToOnDeck = { bookId -> libraryViewModel.moveToOnDeck(bookId) },
+                    onRemoveFromOnDeck = { bookId -> libraryViewModel.removeFromOnDeck(bookId) },
+                    onRefresh = { libraryViewModel.refreshBooks() },
+                    importProgress = importProgress,
+                    isRefreshing = isRefreshing,
+                    scanMessage = scanMessage,
+                    onOpenSettings = {
+                        showSettings = true
+                        settingsScrollTarget = null
                     },
-                    onUpdateReadingPosition = { bookId, currentPage, currentChapter, scrollPosition ->
-                        libraryViewModel.updateReadingPosition(bookId, currentPage, currentChapter, scrollPosition)
-                        // Update the currentBook state with the latest data from the updated allBooks list
-                        currentBook = allBooks.find { it.id == bookId } ?: currentBook
+                    onOpenProgressSettings = {
+                        showSettings = true
+                        settingsScrollTarget = "progress"
                     },
-                    onUpdateBookSettings = { updatedBook ->
-                        libraryViewModel.updateBookSettings(updatedBook)
-                        currentBook = updatedBook  // Update the currentBook state immediately
-                    },
-                    preferencesManager = preferencesManager,
-                    libraryManager = libraryViewModel.libraryManager,
-                    readerViewModel = readerViewModel
+                    showNowPlayingBarPadding = showNowPlayingBar && currentBook == null && !showSettings
                 )
             }
         }
-        else -> {
-            when (selectedTab) {
-                0 -> LibraryScreen(
-                    selectedTab = selectedTab,
-                    onTabSelected = { newTab -> if (newTab in 0..2) selectedTab = newTab },
-                    currentTheme = currentTheme,
-                    onThemeChange = onThemeChange,
-                    theme = theme,
-                    readingBooks = readingBooks,
-                    onDeckBooks = onDeckBooks,
-                    completedBooks = completedBooks,
-                    allBooks = allBooks,
-                    currentlyPlayingAudiobook = allBooks
-                        .filter { it.isAudiobook() }
-                        .filter { it.progress > 0f && it.progress < 1f } // Has been started but not completed
-                        .maxByOrNull { it.lastReadTimestamp }, // Most recently accessed
-                    onNavigateToSettings = { 
-                        showSettings = true
-                        settingsScrollTarget = null
-                    },
-                    onNavigateToProgressSettings = {
-                        showSettings = true
-                        settingsScrollTarget = "progress"
-                    },
-                    onBookClick = { book -> currentBook = book },
-                    onSeeAllClick = { title, books -> seeAllData = title to books },
-                    onStartReading = { bookId -> libraryViewModel.startReading(bookId) },
-                    onMarkCompleted = { bookId -> libraryViewModel.markAsCompleted(bookId) },
-                    onMoveToOnDeck = { bookId -> libraryViewModel.moveToOnDeck(bookId) },
-                    onSetProgress = { bookId, progress -> libraryViewModel.setBookProgress(bookId, progress) },
-                    onEditTags = { bookId, newTags -> libraryViewModel.updateBookTags(bookId, newTags) },
-                    onUpdateBookSettings = { book -> libraryViewModel.updateBookSettings(book) },
-                    onRemoveFromLibrary = { bookId -> libraryViewModel.removeFromLibrary(bookId) },
-                    libraryManager = libraryViewModel.libraryManager,
-                    libraryState = libraryState,
-                    errorMessage = errorMessage,
-                    searchQuery = searchQuery,
-                    onSearchQueryChange = { query -> libraryViewModel.updateSearchQuery(query) },
-                    // Sorting parameters
-                    readingSortAscending = readingSortAscending,
-                    onDeckSortAscending = onDeckSortAscending,
-                    completedSortAscending = completedSortAscending,
-                    onToggleReadingSort = { libraryViewModel.toggleReadingSortOrder() },
-                    onToggleOnDeckSort = { libraryViewModel.toggleOnDeckSortOrder() },
-                    onToggleCompletedSort = { libraryViewModel.toggleCompletedSortOrder() },
-                    onRefresh = { libraryViewModel.refreshBooks() }
-                )
-                1 -> RecentsScreen(
-                    selectedTab = selectedTab,
-                    onTabSelected = { newTab -> if (newTab in 0..2) selectedTab = newTab },
-                    theme = theme,
-                    recentBooks = recentBooks,
-                    onNavigateToSettings = { showSettings = true },
-                    onBookClick = { book -> currentBook = book },
-                    onStartReading = { bookId -> libraryViewModel.startReading(bookId) },
-                    onMarkCompleted = { bookId -> libraryViewModel.markAsCompleted(bookId) },
-                    onMoveToOnDeck = { bookId -> libraryViewModel.moveToOnDeck(bookId) },
-                    onSetProgress = { bookId, progress -> libraryViewModel.setBookProgress(bookId, progress) },
-                    onEditTags = { bookId, newTags -> libraryViewModel.updateBookTags(bookId, newTags) },
-                    onRefresh = { libraryViewModel.refreshBooks() }
-                )
-                2 -> BrowseScreen(
-                    selectedTab = selectedTab,
-                    onTabSelected = { newTab -> if (newTab in 0..2) selectedTab = newTab },
-                    theme = theme,
-                    onNavigateToSettings = { showSettings = true },
-                    onBookClick = { book -> currentBook = book },
-                    onSeeAllClick = { title, books -> seeAllData = title to books },
-                    allBooks = allBooks,
-                    onStartReading = { bookId -> libraryViewModel.startReading(bookId) },
-                    onMarkCompleted = { bookId -> libraryViewModel.markAsCompleted(bookId) },
-                    onMoveToOnDeck = { bookId -> libraryViewModel.moveToOnDeck(bookId) },
-                    onSetProgress = { bookId, progress -> libraryViewModel.setBookProgress(bookId, progress) },
-                    onEditTags = { bookId, newTags -> libraryViewModel.updateBookTags(bookId, newTags) },
-                    onUpdateBookSettings = { book -> libraryViewModel.updateBookSettings(book) },
-                    onRemoveFromLibrary = { bookId -> libraryViewModel.removeBook(bookId) },
-                    onRefresh = { libraryViewModel.refreshBooks() }
-                )
-                else -> LibraryScreen(
-                    selectedTab = 0, // Force to tab 0 when in unknown state
-                    onTabSelected = { newTab -> if (newTab in 0..2) selectedTab = newTab },
-                    currentTheme = currentTheme,
-                    onThemeChange = onThemeChange,
-                    theme = theme,
-                    readingBooks = readingBooks,
-                    onDeckBooks = onDeckBooks,
-                    completedBooks = completedBooks,
-                    allBooks = allBooks,
-                    currentlyPlayingAudiobook = allBooks
-                        .filter { it.isAudiobook() }
-                        .filter { it.progress > 0f && it.progress < 1f } // Has been started but not completed
-                        .maxByOrNull { it.lastReadTimestamp }, // Most recently accessed
-                    onNavigateToSettings = { 
-                        showSettings = true
-                        settingsScrollTarget = null
-                    },
-                    onNavigateToProgressSettings = {
-                        showSettings = true
-                        settingsScrollTarget = "progress"
-                    },
-                    onBookClick = { book -> currentBook = book },
-                    onSeeAllClick = { title, books -> seeAllData = title to books },
-                    onStartReading = { bookId -> libraryViewModel.startReading(bookId) },
-                    onMarkCompleted = { bookId -> libraryViewModel.markAsCompleted(bookId) },
-                    onMoveToOnDeck = { bookId -> libraryViewModel.moveToOnDeck(bookId) },
-                    onSetProgress = { bookId, progress -> libraryViewModel.setBookProgress(bookId, progress) },
-                    onEditTags = { bookId, newTags -> libraryViewModel.updateBookTags(bookId, newTags) },
-                    onUpdateBookSettings = { book -> libraryViewModel.updateBookSettings(book) },
-                    libraryManager = libraryViewModel.libraryManager,
-                    libraryState = libraryState,
-                    errorMessage = errorMessage,
-                    searchQuery = searchQuery,
-                    onSearchQueryChange = { query -> libraryViewModel.updateSearchQuery(query) },
-                    // Sorting parameters
-                    readingSortAscending = readingSortAscending,
-                    onDeckSortAscending = onDeckSortAscending,
-                    completedSortAscending = completedSortAscending,
-                    onToggleReadingSort = { libraryViewModel.toggleReadingSortOrder() },
-                    onToggleOnDeckSort = { libraryViewModel.toggleOnDeckSortOrder() },
-                    onToggleCompletedSort = { libraryViewModel.toggleCompletedSortOrder() },
-                    onRefresh = { libraryViewModel.refreshBooks() }
-                )
-            }
+
+        if (showNowPlayingBar && currentBook == null && !showSettings) {
+            AudioNowPlayingBar(
+                playbackState = playbackState,
+                theme = theme,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                onExpand = {
+                    playbackState.currentBook?.let { book ->
+                        currentBook = book
+                    }
+                },
+                onPlayPause = { audioBookReaderViewModel.togglePlayPause() },
+                onSkipForward = { audioBookReaderViewModel.skipForward() },
+                onSkipBackward = { audioBookReaderViewModel.skipBackward() }
+            )
         }
     }
 }

--- a/app/src/main/java/com/bsikar/helix/ui/screens/ReaderScreen.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/screens/ReaderScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -435,7 +436,7 @@ fun ReaderScreen(
                     if (book.isImported) {
                         IconButton(onClick = { showChapterDialog = true }) {
                             Icon(
-                                Icons.Filled.MenuBook,
+                                Icons.AutoMirrored.Filled.MenuBook,
                                 contentDescription = "Chapters",
                                 tint = theme.secondaryTextColor
                             )

--- a/app/src/main/java/com/bsikar/helix/ui/screens/UnifiedLibraryScreen.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/screens/UnifiedLibraryScreen.kt
@@ -1,0 +1,775 @@
+package com.bsikar.helix.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.LibraryBooks
+import androidx.compose.material.icons.filled.AllInclusive
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Headphones
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.bsikar.helix.data.ImportProgress
+import com.bsikar.helix.data.model.Book
+import com.bsikar.helix.data.model.ReadingStatus
+import com.bsikar.helix.data.model.Tag
+import com.bsikar.helix.data.model.TagCategory
+import com.bsikar.helix.theme.AppTheme
+import com.bsikar.helix.ui.components.CompactImportProgress
+import com.bsikar.helix.ui.components.ResponsiveSpacing
+import com.bsikar.helix.ui.components.SearchBar
+import com.bsikar.helix.ui.components.SearchUtils
+import com.bsikar.helix.viewmodels.LibraryViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UnifiedLibraryScreen(
+    theme: AppTheme,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    contentFilter: LibraryViewModel.LibraryContentFilter,
+    onContentFilterChange: (LibraryViewModel.LibraryContentFilter) -> Unit,
+    activeTagFilters: Set<String>,
+    onToggleTagFilter: (String) -> Unit,
+    onClearTagFilters: () -> Unit,
+    books: List<Book>,
+    allBooks: List<Book>,
+    nowPlayingBookId: String?,
+    onBookClick: (Book) -> Unit,
+    onStartReading: (String) -> Unit,
+    onMarkCompleted: (String) -> Unit,
+    onMoveToOnDeck: (String) -> Unit,
+    onRemoveFromOnDeck: (String) -> Unit,
+    onRefresh: () -> Unit,
+    importProgress: List<ImportProgress>,
+    isRefreshing: Boolean,
+    scanMessage: String,
+    onOpenSettings: () -> Unit,
+    onOpenProgressSettings: () -> Unit,
+    showNowPlayingBarPadding: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val pullToRefreshState = rememberPullToRefreshState()
+
+    val relevantBooks = remember(allBooks, contentFilter) {
+        when (contentFilter) {
+            LibraryViewModel.LibraryContentFilter.ALL -> allBooks
+            LibraryViewModel.LibraryContentFilter.TEXT_ONLY -> allBooks.filter { !it.isAudiobook() }
+            LibraryViewModel.LibraryContentFilter.AUDIO_ONLY -> allBooks.filter { it.isAudiobook() }
+        }
+    }
+
+    val availableTagFilters = remember(relevantBooks) {
+        val usedTags = relevantBooks
+            .flatMap { it.getTagObjects() }
+            .distinctBy { it.id }
+
+        val allowedCategories = when (contentFilter) {
+            LibraryViewModel.LibraryContentFilter.ALL -> setOf(
+                TagCategory.FORMAT,
+                TagCategory.GENRE,
+                TagCategory.DEMOGRAPHIC,
+                TagCategory.THEME,
+                TagCategory.STATUS
+            )
+            LibraryViewModel.LibraryContentFilter.TEXT_ONLY -> setOf(
+                TagCategory.FORMAT,
+                TagCategory.GENRE,
+                TagCategory.DEMOGRAPHIC,
+                TagCategory.THEME,
+                TagCategory.STATUS
+            )
+            LibraryViewModel.LibraryContentFilter.AUDIO_ONLY -> setOf(
+                TagCategory.GENRE,
+                TagCategory.THEME,
+                TagCategory.STATUS
+            )
+        }
+
+        usedTags
+            .filter { it.category in allowedCategories }
+            .groupBy { it.category }
+            .mapValues { (_, value) -> value.sortedBy { it.displayName.lowercase() } }
+    }
+
+    val inProgressBooks = remember(books) {
+        books.filter { it.readingStatus == ReadingStatus.READING || it.readingStatus == ReadingStatus.LISTENING }
+            .sortedByDescending { it.lastReadTimestamp }
+    }
+
+    val onDeckBooks = remember(books) {
+        books.filter { it.readingStatus == ReadingStatus.PLAN_TO_READ || it.readingStatus == ReadingStatus.PLAN_TO_LISTEN }
+            .sortedBy { it.title }
+    }
+
+    val completedBooks = remember(books) {
+        books.filter { it.readingStatus == ReadingStatus.COMPLETED }
+            .sortedByDescending { it.lastReadTimestamp }
+    }
+
+    val backlogBooks = remember(books) {
+        books.filter { it.readingStatus == ReadingStatus.UNREAD }
+            .sortedBy { it.title }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = theme.backgroundColor,
+        topBar = {
+            androidx.compose.material3.TopAppBar(
+                title = {
+                    Text(
+                        text = "Library",
+                        color = theme.primaryTextColor,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = theme.surfaceColor,
+                    titleContentColor = theme.primaryTextColor
+                ),
+                actions = {
+                    IconButton(onClick = onOpenProgressSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Tune,
+                            contentDescription = "Progress Settings",
+                            tint = theme.primaryTextColor
+                        )
+                    }
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = "Settings",
+                            tint = theme.primaryTextColor
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        PullToRefreshBox(
+            modifier = Modifier
+                .fillMaxSize(),
+            isRefreshing = isRefreshing,
+            onRefresh = onRefresh,
+            state = pullToRefreshState
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentPadding = PaddingValues(
+                    start = ResponsiveSpacing.medium(),
+                    end = ResponsiveSpacing.medium(),
+                    top = innerPadding.calculateTopPadding() + ResponsiveSpacing.medium(),
+                    bottom = if (showNowPlayingBarPadding) 128.dp else ResponsiveSpacing.large()
+                ),
+                verticalArrangement = Arrangement.spacedBy(ResponsiveSpacing.medium())
+            ) {
+                item {
+                    SearchBar(
+                        value = searchQuery,
+                        onValueChange = onSearchQueryChange,
+                        theme = theme
+                    )
+                }
+
+                item {
+                    ContentFilterRow(
+                        theme = theme,
+                        currentFilter = contentFilter,
+                        onFilterSelected = onContentFilterChange
+                    )
+                }
+
+                if (availableTagFilters.isNotEmpty()) {
+                    item {
+                        SecondaryFilterSection(
+                            theme = theme,
+                            categories = availableTagFilters,
+                            activeTagFilters = activeTagFilters,
+                            onToggleTag = onToggleTagFilter,
+                            onClearFilters = onClearTagFilters
+                        )
+                    }
+                }
+
+                if (scanMessage.isNotBlank()) {
+                    item {
+                        InfoBanner(
+                            message = scanMessage,
+                            theme = theme
+                        )
+                    }
+                }
+
+                if (importProgress.isNotEmpty()) {
+                    item {
+                        CompactImportProgress(
+                            activeImports = importProgress,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
+                if (books.isEmpty()) {
+                    item {
+                        EmptyState(theme = theme)
+                    }
+                } else {
+                    if (inProgressBooks.isNotEmpty()) {
+                        item { LibrarySectionHeader("In Progress", theme) }
+                        items(inProgressBooks, key = { it.id }) { book ->
+                            LibraryListItem(
+                                book = book,
+                                theme = theme,
+                                searchQuery = searchQuery,
+                                nowPlayingBookId = nowPlayingBookId,
+                                onBookClick = onBookClick,
+                                onStartReading = onStartReading,
+                                onMarkCompleted = onMarkCompleted,
+                                onMoveToOnDeck = onMoveToOnDeck,
+                                onRemoveFromOnDeck = onRemoveFromOnDeck
+                            )
+                        }
+                    }
+
+                    if (onDeckBooks.isNotEmpty()) {
+                        item { LibrarySectionHeader("On Deck", theme) }
+                        items(onDeckBooks, key = { it.id }) { book ->
+                            LibraryListItem(
+                                book = book,
+                                theme = theme,
+                                searchQuery = searchQuery,
+                                nowPlayingBookId = nowPlayingBookId,
+                                onBookClick = onBookClick,
+                                onStartReading = onStartReading,
+                                onMarkCompleted = onMarkCompleted,
+                                onMoveToOnDeck = onMoveToOnDeck,
+                                onRemoveFromOnDeck = onRemoveFromOnDeck
+                            )
+                        }
+                    }
+
+                    if (backlogBooks.isNotEmpty()) {
+                        item { LibrarySectionHeader("Up Next", theme) }
+                        items(backlogBooks, key = { it.id }) { book ->
+                            LibraryListItem(
+                                book = book,
+                                theme = theme,
+                                searchQuery = searchQuery,
+                                nowPlayingBookId = nowPlayingBookId,
+                                onBookClick = onBookClick,
+                                onStartReading = onStartReading,
+                                onMarkCompleted = onMarkCompleted,
+                                onMoveToOnDeck = onMoveToOnDeck,
+                                onRemoveFromOnDeck = onRemoveFromOnDeck
+                            )
+                        }
+                    }
+
+                    if (completedBooks.isNotEmpty()) {
+                        item { LibrarySectionHeader("Completed", theme) }
+                        items(completedBooks, key = { it.id }) { book ->
+                            LibraryListItem(
+                                book = book,
+                                theme = theme,
+                                searchQuery = searchQuery,
+                                nowPlayingBookId = nowPlayingBookId,
+                                onBookClick = onBookClick,
+                                onStartReading = onStartReading,
+                                onMarkCompleted = onMarkCompleted,
+                                onMoveToOnDeck = onMoveToOnDeck,
+                                onRemoveFromOnDeck = onRemoveFromOnDeck
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContentFilterRow(
+    theme: AppTheme,
+    currentFilter: LibraryViewModel.LibraryContentFilter,
+    onFilterSelected: (LibraryViewModel.LibraryContentFilter) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = ResponsiveSpacing.small()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        FilterChip(
+            selected = currentFilter == LibraryViewModel.LibraryContentFilter.ALL,
+            onClick = { onFilterSelected(LibraryViewModel.LibraryContentFilter.ALL) },
+            label = { Text("All") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.AllInclusive,
+                    contentDescription = null
+                )
+            },
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = theme.surfaceColor,
+                selectedContainerColor = theme.accentColor.copy(alpha = theme.alphaSubtle),
+                labelColor = theme.primaryTextColor,
+                selectedLabelColor = theme.accentColor
+            )
+        )
+
+        FilterChip(
+            selected = currentFilter == LibraryViewModel.LibraryContentFilter.TEXT_ONLY,
+            onClick = { onFilterSelected(LibraryViewModel.LibraryContentFilter.TEXT_ONLY) },
+            label = { Text("Text") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.LibraryBooks,
+                    contentDescription = null
+                )
+            },
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = theme.surfaceColor,
+                selectedContainerColor = theme.accentColor.copy(alpha = theme.alphaSubtle),
+                labelColor = theme.primaryTextColor,
+                selectedLabelColor = theme.accentColor
+            )
+        )
+
+        FilterChip(
+            selected = currentFilter == LibraryViewModel.LibraryContentFilter.AUDIO_ONLY,
+            onClick = { onFilterSelected(LibraryViewModel.LibraryContentFilter.AUDIO_ONLY) },
+            label = { Text("Audio") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Headphones,
+                    contentDescription = null
+                )
+            },
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = theme.surfaceColor,
+                selectedContainerColor = theme.accentColor.copy(alpha = theme.alphaSubtle),
+                labelColor = theme.primaryTextColor,
+                selectedLabelColor = theme.accentColor
+            )
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun SecondaryFilterSection(
+    theme: AppTheme,
+    categories: Map<TagCategory, List<Tag>>,
+    activeTagFilters: Set<String>,
+    onToggleTag: (String) -> Unit,
+    onClearFilters: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(theme.surfaceColor.copy(alpha = 0.7f))
+            .padding(ResponsiveSpacing.medium())
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Refine",
+                style = MaterialTheme.typography.titleSmall,
+                color = theme.primaryTextColor,
+                fontWeight = FontWeight.Medium
+            )
+
+            if (activeTagFilters.isNotEmpty()) {
+                AssistChip(
+                    onClick = onClearFilters,
+                    label = { Text("Clear") },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = null
+                        )
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = theme.surfaceColor,
+                        labelColor = theme.secondaryTextColor
+                    )
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        categories.forEach { (category, tags) ->
+            if (tags.isNotEmpty()) {
+                Text(
+                    text = category.displayName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = theme.secondaryTextColor,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    tags.forEach { tag ->
+                        val selected = activeTagFilters.contains(tag.id)
+                        FilterChip(
+                            selected = selected,
+                            onClick = { onToggleTag(tag.id) },
+                            label = { Text(tag.displayName) },
+                            colors = FilterChipDefaults.filterChipColors(
+                                containerColor = theme.surfaceColor,
+                                selectedContainerColor = theme.accentColor.copy(alpha = theme.alphaSubtle),
+                                labelColor = if (selected) theme.accentColor else theme.primaryTextColor,
+                                selectedLabelColor = theme.accentColor
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibrarySectionHeader(title: String, theme: AppTheme) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = theme.primaryTextColor,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = ResponsiveSpacing.small())
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun LibraryListItem(
+    book: Book,
+    theme: AppTheme,
+    searchQuery: String,
+    nowPlayingBookId: String?,
+    onBookClick: (Book) -> Unit,
+    onStartReading: (String) -> Unit,
+    onMarkCompleted: (String) -> Unit,
+    onMoveToOnDeck: (String) -> Unit,
+    onRemoveFromOnDeck: (String) -> Unit
+) {
+    val progress = if (book.isAudiobook()) book.getAudioProgress() else book.progress
+    val statusLabel = when (book.readingStatus) {
+        ReadingStatus.READING -> if (book.isAudiobook()) "Listening" else "Reading"
+        ReadingStatus.LISTENING -> "Listening"
+        ReadingStatus.PLAN_TO_READ -> "On Deck"
+        ReadingStatus.PLAN_TO_LISTEN -> "On Deck"
+        ReadingStatus.COMPLETED -> "Completed"
+        ReadingStatus.UNREAD -> "Not Started"
+    }
+
+    val statusColor = when (book.readingStatus) {
+        ReadingStatus.COMPLETED -> theme.successColor
+        ReadingStatus.READING, ReadingStatus.LISTENING -> theme.accentColor
+        ReadingStatus.PLAN_TO_READ, ReadingStatus.PLAN_TO_LISTEN -> theme.warningColor
+        ReadingStatus.UNREAD -> theme.secondaryTextColor
+    }
+
+    val quickActions = remember(book) {
+        buildList {
+            if (book.readingStatus != ReadingStatus.COMPLETED) {
+                add(
+                    QuickAction(
+                        label = if (book.readingStatus == ReadingStatus.READING || book.readingStatus == ReadingStatus.LISTENING) {
+                            "Resume"
+                        } else if (book.isAudiobook()) {
+                            "Start Listening"
+                        } else {
+                            "Start Reading"
+                        },
+                        icon = Icons.Filled.PlayArrow,
+                        onClick = { onStartReading(book.id) }
+                    )
+                )
+            } else {
+                add(
+                    QuickAction(
+                        label = "Restart",
+                        icon = Icons.Filled.Replay,
+                        onClick = { onStartReading(book.id) }
+                    )
+                )
+            }
+
+            when (book.readingStatus) {
+                ReadingStatus.PLAN_TO_READ, ReadingStatus.PLAN_TO_LISTEN -> {
+                    add(
+                        QuickAction(
+                            label = "Remove On Deck",
+                            icon = Icons.Filled.Close,
+                            onClick = { onRemoveFromOnDeck(book.id) }
+                        )
+                    )
+                }
+                ReadingStatus.UNREAD, ReadingStatus.COMPLETED -> {
+                    add(
+                        QuickAction(
+                            label = "Add to On Deck",
+                            icon = Icons.Filled.Schedule,
+                            onClick = { onMoveToOnDeck(book.id) }
+                        )
+                    )
+                }
+                else -> Unit
+            }
+
+            if (book.readingStatus != ReadingStatus.COMPLETED) {
+                add(
+                    QuickAction(
+                        label = "Mark Complete",
+                        icon = Icons.Filled.CheckCircle,
+                        onClick = { onMarkCompleted(book.id) }
+                    )
+                )
+            }
+        }
+    }
+
+    Card(
+        onClick = { onBookClick(book) },
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = theme.surfaceColor
+        ),
+        border = if (nowPlayingBookId != null && nowPlayingBookId == book.id) {
+            BorderStroke(1.5.dp, theme.accentColor)
+        } else null
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 72.dp, height = 96.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(book.getEffectiveCoverColor()),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (book.shouldShowCoverArt() && !book.coverImagePath.isNullOrBlank()) {
+                        AsyncImage(
+                            model = book.coverImagePath,
+                            contentDescription = book.title,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.PlayArrow,
+                            contentDescription = null,
+                            tint = theme.primaryTextColor.copy(alpha = theme.alphaMedium)
+                        )
+                    }
+                }
+
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = SearchUtils.createHighlightedText(
+                            text = book.title,
+                            query = searchQuery,
+                            baseColor = theme.primaryTextColor,
+                            highlightColor = theme.accentColor
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    if (book.author.isNotBlank()) {
+                        Text(
+                            text = SearchUtils.createHighlightedText(
+                                text = book.author,
+                                query = searchQuery,
+                                baseColor = theme.secondaryTextColor,
+                                highlightColor = theme.accentColor,
+                                fontSize = 12.sp
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(statusColor.copy(alpha = theme.alphaSubtle))
+                            .padding(horizontal = 10.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = statusLabel,
+                            color = statusColor,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+
+                    if (progress > 0f && progress < 1f) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        LinearProgressIndicator(
+                            progress = { progress },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(4.dp)),
+                            color = theme.accentColor,
+                            trackColor = theme.accentColor.copy(alpha = theme.alphaSubtle)
+                        )
+                    }
+                }
+            }
+
+            if (quickActions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    quickActions.forEach { action ->
+                        AssistChip(
+                            onClick = action.onClick,
+                            label = { Text(action.label) },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = action.icon,
+                                    contentDescription = action.label
+                                )
+                            },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = theme.surfaceColor,
+                                labelColor = theme.primaryTextColor
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoBanner(message: String, theme: AppTheme) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(theme.accentColor.copy(alpha = theme.alphaSubtle))
+            .padding(16.dp)
+    ) {
+        Text(
+            text = message,
+            color = theme.accentColor,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun EmptyState(theme: AppTheme) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(theme.surfaceColor)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "No items match your filters yet.",
+            color = theme.primaryTextColor,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Try adjusting the filters or importing new books to get started.",
+            color = theme.secondaryTextColor,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+private data class QuickAction(
+    val label: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/com/bsikar/helix/ui/screens/UnifiedLibraryScreen.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/screens/UnifiedLibraryScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.bsikar.helix.data.ImportProgress
+import com.bsikar.helix.data.model.ImportProgress
 import com.bsikar.helix.data.model.Book
 import com.bsikar.helix.data.model.ReadingStatus
 import com.bsikar.helix.data.model.Tag
@@ -137,7 +137,7 @@ fun UnifiedLibraryScreen(
         usedTags
             .filter { it.category in allowedCategories }
             .groupBy { it.category }
-            .mapValues { (_, value) -> value.sortedBy { it.displayName.lowercase() } }
+            .mapValues { (_, value) -> value.sortedBy { it.name.lowercase() } }
     }
 
     val inProgressBooks = remember(books) {
@@ -472,7 +472,7 @@ private fun SecondaryFilterSection(
                         FilterChip(
                             selected = selected,
                             onClick = { onToggleTag(tag.id) },
-                            label = { Text(tag.displayName) },
+                            label = { Text(tag.name) },
                             colors = FilterChipDefaults.filterChipColors(
                                 containerColor = theme.surfaceColor,
                                 selectedContainerColor = theme.accentColor.copy(alpha = theme.alphaSubtle),

--- a/app/src/main/java/com/bsikar/helix/viewmodels/LibraryViewModel.kt
+++ b/app/src/main/java/com/bsikar/helix/viewmodels/LibraryViewModel.kt
@@ -153,6 +153,9 @@ class LibraryViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = emptyList()
     )
+    
+    // Debounced search query for better performance
+    private val debouncedSearchQuery = searchQuery.debounce(300)
 
     val filteredLibraryBooks: StateFlow<List<com.bsikar.helix.data.model.Book>> = combine(
         allBooks,
@@ -182,9 +185,6 @@ class LibraryViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = emptyList()
     )
-
-    // Debounced search query for better performance
-    private val debouncedSearchQuery = searchQuery.debounce(300)
 
     // Filtered and sorted reading books
     val filteredReadingBooks: StateFlow<List<com.bsikar.helix.data.model.Book>> = combine(


### PR DESCRIPTION
## Summary
- replace the tab navigation with a new UnifiedLibraryScreen that merges library, browse, and recents into a single view with search, primary content filters, and tag-based refinements
- add inline quick actions and sectioned lists so books can be started, queued, or completed directly from the main screen, while showing import status and scan messaging in context
- expose filtering state in LibraryViewModel and surface a persistent AudioNowPlayingBar so active audiobooks stay controllable across the app

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd1a2c22c8327a32f53d1b3fa3805