### PR TITLE
Refactor library into unified screen with persistent audio bar

### DIFF
--- a/app/src/main/java/com/bsikar/helix/data/model/UiState.kt
+++ b/app/src/main/java/com/bsikar/helix/data/model/UiState.kt
@@ -39,3 +39,10 @@ inline fun <T> UiState<T>.onError(action: (Throwable) -> Unit): UiState<T> {
     if (this is UiState.Error) action(exception)
     return this
 }
+
+fun <T> Result<T>.toUiState(): UiState<T> {
+    return fold(
+        onSuccess = { UiState.Success(it) },
+        onFailure = { UiState.Error(it) }
+    )
+}

--- a/app/src/main/java/com/bsikar/helix/ui/components/PersistentAudioBar.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/components/PersistentAudioBar.kt
@@ -1,0 +1,159 @@
+package com.bsikar.helix.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.bsikar.helix.player.PlaybackState
+import com.bsikar.helix.theme.AppTheme
+
+@Composable
+fun PersistentAudioBar(
+    playbackState: PlaybackState,
+    theme: AppTheme,
+    modifier: Modifier = Modifier,
+    onExpand: () -> Unit,
+    onPlayPause: () -> Unit
+) {
+    val book = playbackState.currentBook ?: return
+    val progress = when {
+        playbackState.durationMs > 0 -> (playbackState.currentPositionMs.toFloat() / playbackState.durationMs.toFloat()).coerceIn(0f, 1f)
+        book.durationMs > 0 -> book.getAudioProgress()
+        else -> 0f
+    }
+
+    Surface(
+        modifier = modifier,
+        color = theme.surfaceColor,
+        tonalElevation = 6.dp,
+        shadowElevation = 10.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ) { onExpand() },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Card(
+                    modifier = Modifier
+                        .size(52.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (book.shouldShowCoverArt() && !book.coverImagePath.isNullOrBlank()) {
+                            Color.Transparent
+                        } else {
+                            book.getEffectiveCoverColor()
+                        }
+                    )
+                ) {
+                    if (book.shouldShowCoverArt() && !book.coverImagePath.isNullOrBlank()) {
+                        AsyncImage(
+                            model = book.coverImagePath,
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                Icons.Filled.PlayArrow,
+                                contentDescription = null,
+                                tint = Color.White.copy(alpha = 0.85f)
+                            )
+                        }
+                    }
+                }
+
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = book.title,
+                        color = theme.primaryTextColor,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    val subtitle = buildString {
+                        if (book.author.isNotBlank()) {
+                            append(book.author)
+                        }
+                        val position = book.getFormattedPosition()
+                        val duration = book.getFormattedDuration()
+                        if (position.isNotBlank() && duration.isNotBlank()) {
+                            if (isNotEmpty()) {
+                                append(" • ")
+                            }
+                            append(position)
+                            append(" / ")
+                            append(duration)
+                        }
+                    }
+                    Text(
+                        text = subtitle,
+                        color = theme.secondaryTextColor,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                IconButton(onClick = onPlayPause) {
+                    Icon(
+                        imageVector = if (playbackState.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
+                        tint = theme.accentColor
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { progress },
+                color = theme.accentColor,
+                trackColor = theme.secondaryTextColor.copy(alpha = 0.2f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(2.dp))
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bsikar/helix/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/bsikar/helix/ui/screens/LibraryScreen.kt
@@ -456,13 +456,14 @@ fun LibraryScreen(
             if (inProgressBooks.isNotEmpty()) {
                 val sectionKey = "in_progress_books_${inProgressBooks.size}"
                 item(key = "in_progress_header") {
+                    val inProgressTitleString = stringResource(id = inProgressTitleRes)
                     LibrarySectionHeader(
-                        title = stringResource(id = inProgressTitleRes),
+                        title = inProgressTitleString,
                         subtitle = stringResource(id = inProgressSubtitleRes),
                         theme = theme,
                         isAscending = readingSortAscending,
                         onSortClick = onToggleReadingSort,
-                        onSeeAllClick = { onSeeAllClick(stringResource(id = inProgressTitleRes), inProgressBooks) }
+                        onSeeAllClick = { onSeeAllClick(inProgressTitleString, inProgressBooks) }
                     )
                 }
                 item(key = sectionKey) {
@@ -479,13 +480,14 @@ fun LibraryScreen(
                     else -> R.string.section_on_deck_all
                 }
                 item(key = "plan_to_read_header") {
+                    val onDeckTitleString = stringResource(id = onDeckTitleRes)
                     LibrarySectionHeader(
-                        title = stringResource(id = onDeckTitleRes),
+                        title = onDeckTitleString,
                         subtitle = "Title",
                         theme = theme,
                         isAscending = onDeckSortAscending,
                         onSortClick = onToggleOnDeckSort,
-                        onSeeAllClick = { onSeeAllClick(stringResource(id = onDeckTitleRes), internalOnDeckBooks) }
+                        onSeeAllClick = { onSeeAllClick(onDeckTitleString, internalOnDeckBooks) }
                     )
                 }
                 item(key = "on_deck_books_${internalOnDeckBooks.size}") {
@@ -502,13 +504,14 @@ fun LibraryScreen(
                     else -> R.string.section_completed_all
                 }
                 item(key = "read_header") {
+                    val completedTitleString = stringResource(id = completedTitleRes)
                     LibrarySectionHeader(
-                        title = stringResource(id = completedTitleRes),
+                        title = completedTitleString,
                         subtitle = "Title",
                         theme = theme,
                         isAscending = completedSortAscending,
                         onSortClick = onToggleCompletedSort,
-                        onSeeAllClick = { onSeeAllClick(stringResource(id = completedTitleRes), internalCompletedBooks) }
+                        onSeeAllClick = { onSeeAllClick(completedTitleString, internalCompletedBooks) }
                     )
                 }
                 item(key = "read_books_${internalCompletedBooks.size}") {

--- a/app/src/main/java/com/bsikar/helix/viewmodels/LibraryViewModel.kt
+++ b/app/src/main/java/com/bsikar/helix/viewmodels/LibraryViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import com.bsikar.helix.data.model.UiState
+import com.bsikar.helix.data.model.toUiState
 import com.bsikar.helix.ui.components.SearchUtils
 
 enum class LibraryContentFilter {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,26 @@
     <string name="found_new_books">Found %d new books!</string>
     <string name="no_new_books_found">No new books found</string>
     <string name="scan_failed">Scan failed: %s</string>
-    
+
+    <!-- Filters -->
+    <string name="filter_all_content">All</string>
+    <string name="filter_text_only">Text</string>
+    <string name="filter_audio_only">Audio</string>
+    <string name="filter_refine_results">Refine results</string>
+    <string name="filter_clear">Clear</string>
+
+    <!-- Unified library sections -->
+    <string name="section_in_progress_all">In Progress</string>
+    <string name="section_in_progress_text">Reading</string>
+    <string name="section_in_progress_audio">Listening</string>
+    <string name="section_in_progress_subtitle_all">Last activity</string>
+    <string name="section_in_progress_subtitle_text">Last read</string>
+    <string name="section_in_progress_subtitle_audio">Last played</string>
+    <string name="section_on_deck_all">On Deck</string>
+    <string name="section_on_deck_audio">Listening Queue</string>
+    <string name="section_completed_all">Finished</string>
+    <string name="section_completed_audio">Finished Listening</string>
+
     <!-- Import -->
     <string name="import_epub">Import EPUB</string>
     <string name="importing">Importing...</string>


### PR DESCRIPTION
## Summary
- consolidate the main navigation into a single LibraryScreen with search, primary filter chips, and secondary tag filters
- add a persistent Spotify-style audio bar component that surfaces the current audiobook and links to the full player
- extend the library view model and string resources to support content filtering, stacked tag filters, and the new UI copy

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: requires local Android SDK path)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd1a2c22c8327a32f53d1b3fa3805